### PR TITLE
add: Nix support using a flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,181 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "lean": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "lean4-mode": "lean4-mode",
+        "nix": "nix",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1699662927,
+        "narHash": "sha256-vCzGUm3gZPwzrzK76jtFKAkP38D4t7XR9w+5D6UM4bE=",
+        "owner": "leanprover",
+        "repo": "lean4",
+        "rev": "1f68dec119c7b072c329252f482a57d9f5c09906",
+        "type": "github"
+      },
+      "original": {
+        "owner": "leanprover",
+        "repo": "lean4",
+        "type": "github"
+      }
+    },
+    "lean4-mode": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1676498134,
+        "narHash": "sha256-u3WvyKxOViZG53hkb8wd2/Og6muTecbh+NdflIgVeyk=",
+        "owner": "leanprover",
+        "repo": "lean4-mode",
+        "rev": "2c6ef33f476fdf5eb5e4fa4fa023ba8b11372440",
+        "type": "github"
+      },
+      "original": {
+        "owner": "leanprover",
+        "repo": "lean4-mode",
+        "type": "github"
+      }
+    },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1657097207,
+        "narHash": "sha256-SmeGmjWM3fEed3kQjqIAO8VpGmkC2sL1aPE7kKpK650=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "f6316b49a0c37172bca87ede6ea8144d7d89832f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1653988320,
+        "narHash": "sha256-ZaqFFsSDipZ6KVqriwM34T739+KLYJvNmCWzErjAg7c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2fa57ed190fd6c7c746319444f34b5917666e5c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-regression": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1686089707,
+        "narHash": "sha256-LTNlJcru2qJ0XhlhG9Acp5KyjB774Pza3tRH0pKIb3o=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "af21c31b2a1ec5d361ed8050edd0303c31306397",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "lean": "lean"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,28 @@
+{
+  nixConfig.trusted-substituters = "https://lean4.cachix.org/";
+  nixConfig.trusted-public-keys = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= lean4.cachix.org-1:mawtxSxcaiWE24xCXXgh3qnvlTkyU7evRRnGeAhD4Wk=";
+  nixConfig.max-jobs = "auto"; # Allow building multiple derivations in parallel
+  # nixConfig.keep-outputs = true; # Do not garbage-collect build time-only dependencies (e.g. clang)
+
+  description = "Standard Library for Lean 4";
+
+  inputs.lean.url = "github:leanprover/lean4";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, lean, flake-utils, ... }@inputs: flake-utils.lib.eachDefaultSystem (system:
+    let
+      leanPkgs = lean.packages.${system};
+      std4 = leanPkgs.buildLeanPackage {
+        name = "Std"; # must match the name of the top-level .lean file
+        src = ./.;
+        precompilePackage = true;
+      };
+    in
+    {
+      packages = std4 // {
+        inherit (leanPkgs) lean;
+      };
+
+      defaultPackage = std4.modRoot;
+    });
+}


### PR DESCRIPTION
While reading through [the lean setup guide's section regarding Nix](https://lean-lang.org/lean4/doc/setup/nix.html), I could not find any references about how to include Mathlib, when setting up Lean this way. I found [some attempts by other people before me](https://github.com/stites/templates/blob/492ffebb29b479d3ee85fa24beb214ecb227fbb0/lean4/flake.nix) trying to accomplish that, however I could not reproduce their results.

This made me implement my own method of import Mathlib using Nix. However, I keep getting the following error:

```bash
error: builder for '/nix/store/p34fbp470fpfhdd94swyjckrjsp85zf0-Std.Data.Char.drv' failed with exit code 1;
       last 10 log lines:
       >
       > case inr.inl
       > c : Char
       > h✝ : csize c = 2
       > ⊢ 2 ≤ 4
       >
       > case inr.inr.inl
       > c : Char
       > h✝ : csize c = 3
       > ⊢ 3 ≤ 4
       For full logs, run 'nix log /nix/store/p34fbp470fpfhdd94swyjckrjsp85zf0-Std.Data.Char.drv'.
error: 1 dependencies of derivation '/nix/store/zirf62j47hwnnpmgdhglwvmz04jdfgq1-Std-depRoot-env.drv' failed to build
```

when I try to use the following `flake.nix`:

```nix
{
  nixConfig.trusted-substituters = "https://lean4.cachix.org/";
  nixConfig.trusted-public-keys = "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= lean4.cachix.org-1:mawtxSxcaiWE24xCXXgh3qnvlTkyU7evRRnGeAhD4Wk=";
  nixConfig.max-jobs = "auto"; # Allow building multiple derivations in parallel
  # nixConfig.keep-outputs = true; # Do not garbage-collect build time-only dependencies (e.g. clang)

  inputs.lean.url = "github:leanprover/lean4";
  # Here we will add our dependency on Mathlib
  # I stole this from https://github.com/stites/templates/blob/492ffebb29b479d3ee85fa24beb214ecb227fbb0/lean4/flake.nix
  inputs.mathlib4.url = "github:leanprover-community/mathlib4?ref=v4.2.0";
  inputs.mathlib4.flake = false;
  inputs.aesop.url = "github:JLimperg/aesop?ref=v4.2.0";
  inputs.aesop.flake = false;
  inputs.quote.url = "github:leanprover-community/quote4";
  inputs.quote.flake = false;
  inputs.std4.url = "github:leanprover/std4?ref=v4.3.0-rc1";
  inputs.std4.flake = false;
  inputs.proofWidgets4.url = "github:leanprover-community/ProofWidgets4?ref=v0.0.22";
  inputs.proofWidgets4.flake = false;
  inputs.flake-utils.url = "github:numtide/flake-utils";

  outputs = { self, lean, flake-utils, ... }@inputs: flake-utils.lib.eachDefaultSystem (system:
    let
      leanPkgs = lean.packages.${system};
      pkg = leanPkgs.buildLeanPackage {
        name = "MyPackage"; # must match the name of the top-level .lean file
        src = ./.;
      };
      aesop = leanPkgs.buildLeanPackage {
        name = "Aesop";
        src = inputs.aesop;
        precompilePackage = true;
        deps = [ std4 ];
      };
      quote = leanPkgs.buildLeanPackage {
        name = "Qq";
        src = inputs.quote;
        precompilePackage = true;
      };
      std4 = leanPkgs.buildLeanPackage {
        name = "Std";
        src = inputs.std4;
        precompilePackage = true;
      };
      proofWidgets4 = leanPkgs.buildLeanPackage {
        name = "ProofWidgets";
        src = inputs.proofWidgets4;
        precompilePackage = true;
      };
      mathlib = leanPkgs.buildLeanPackage {
        name = "Mathlib";
        src = inputs.mathlib4;
        precompilePackage = true;
        deps = [
          aesop
          quote
          std4
          proofWidgets4
          # optional doc-gen4
        ];
      };
    in
    {
      packages = pkg // {
        inherit (leanPkgs) lean;
      } // mathlib;

      defaultPackage = pkg.modRoot;
    });
}
```

This PR will fix that (hopefully).

---

For further information about Nix and its usage inside Lean: https://lean-lang.org/lean4/doc/setup/nix.html